### PR TITLE
Fix placing

### DIFF
--- a/app/components/quote-bubble.js
+++ b/app/components/quote-bubble.js
@@ -7,22 +7,32 @@ export default Ember.Component.extend({
 	text: null,
   placeRandomly: false,
   quoteBubblesPositionsService: Ember.inject.service(),
+	store: Ember.inject.service(),
 
-	didRender(){
+	didInsertElement(){
 		let quoteBubblesPositionsService = this.get('quoteBubblesPositionsService');
 		if ( quoteBubblesPositionsService.isDocumentFull() ){
-			console.log("ITS FULL");
+			console.log("ITS FULL from components/quote-bubble");
 
 			// TODO App should only fetch as many quotes as necessary
 			// to fill the viewport on entering into the route.
 			// Will refactor this out later.
 			this.$().remove();
 		} else {
-			let position = quoteBubblesPositionsService.generateNotOverlappingPosition();
-			console.log('random position: ' + JSON.stringify(position));
-			this.$().css({ left: `${position.left}px`,
-										 top:  `${position.top}px`,
-										 position: 'absolute' });
+			let dimensions = this.$()[0].getBoundingClientRect();
+
+			// Needed because these dimensions will be createRecorded into ember data as quote-bubble
+			// and they will need an id.
+			dimensions.id = this.$()[0].id;
+			let position = quoteBubblesPositionsService.generateNotOverlappingPosition(dimensions);
+			this.$().css({
+				left: `${position.left}px`,
+			  top:  `${position.top}px`,
+        position: 'absolute'
+			});
 		}
+	},
+
+	didRender(){
 	}
 });

--- a/app/initializers/resize-document.js
+++ b/app/initializers/resize-document.js
@@ -3,12 +3,12 @@ export function initialize(/* container, application */) {
   let doc = $(document);
   let documentHeight = doc.height();
   let documentWidth = doc.width();
-  console.log('Original Height: ' + documentHeight + "Original Width: " + documentWidth);
+  console.log('Original Height: ' + documentHeight + " Original Width: " + documentWidth);
 
   let resizedElement = $('body');
   resizedElement.height(3*documentHeight);
   resizedElement.width( 3*documentWidth);
-  console.log('New Height: ' + resizedElement.height()  + "New Width: " + resizedElement.width());
+  console.log('New Height: ' + resizedElement.height()  + " New Width: " + resizedElement.width());
 }
 
 export default {

--- a/app/mirage/scenarios/default.js
+++ b/app/mirage/scenarios/default.js
@@ -2,5 +2,5 @@ export default function(server) {
   // Seed your development database using your factories. This
   // data will not be loaded in your tests.
 
-  server.createList('quote', 100);
+  server.createList('quote', 35);
 }

--- a/app/models/quote-bubble.js
+++ b/app/models/quote-bubble.js
@@ -1,0 +1,20 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Model.extend({
+  bottom: DS.attr('integer'),
+  height: DS.attr('integer'),
+  left: DS.attr('integer'),
+  right: DS.attr('integer'),
+  top: DS.attr('integer'),
+  width: DS.attr('integer'),
+
+  coordinates: Ember.computed('top', 'bottom','left','right', function() {
+    return {
+      top: this.get('top'),
+      bottom: this.get('bottom'),
+      left: this.get('left'),
+      right: this.get('right')
+    };
+  })
+});

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "pretender": "~0.10.1",

--- a/tests/unit/models/quote-bubble-test.js
+++ b/tests/unit/models/quote-bubble-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('quote-bubble', 'Unit | Model | quote bubble', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  var model = this.subject();
+  // var store = this.store();
+  assert.ok(!!model);
+});


### PR DESCRIPTION
Currently quote-bubbles are placed with overlap because I wasn't actually comparing the same properties against one another, ie, css top v css top.  Instead it does a quick and dirty comparison with `averageHeight` and `averageWidth` properties leading to inaccurate comparisons.

This fixes that and bubbles are placed without overlap but the algo needs to get faster.
## Implementation

I swapped out my `quote-bubble-positions-service.positions` - which was just an array of hashes which contained top,left,right and bottom properties - with an ember data quote-bubble model.  I was basically building an identity map from scratch and figured this would be easier, though it probably affects perf adversely.
## ToDo
- [ ] Get infinite scrolling working in every direction
- [ ] After that, keyboard shortcuts to move around
- [ ] Optimize quote-placing algo by actually calculating how many can fit on the user's viewport, and then retrieving exactly that many records as opposed to `return this.store.findAll('quote');`
